### PR TITLE
Refactor and mocking unit test for bigquery.py

### DIFF
--- a/src/lib/bigquery.py
+++ b/src/lib/bigquery.py
@@ -104,8 +104,9 @@ class Bigquery:
 
         except BadRequest as e:
             if e.errors[0]["message"].find("Invalid table ID") > -1:
-                is_success = self.config.ignore_table_not_found_error_when_restore
-                return BqUpdateResult(is_success, ResultType.TABLE_NOT_FOUND, detail=str(e))
+                if self.config.ignore_table_not_found_error_when_restore:
+                    return BqUpdateResult(True, ResultType.TABLE_NOT_FOUND, detail=str(e))
+                return BqUpdateResult(False, ResultType.TABLE_NOT_FOUND, detail=str(e))
             raise e
 
         is_same, diff_msg = new_table_desc.check_diff(existing_table_desc)

--- a/src/lib/bigquery.py
+++ b/src/lib/bigquery.py
@@ -41,19 +41,14 @@ class Bigquery:
     # -------------------------------
 
     def list_project_id(self, include_pattern=MATCH_ALL, exclude_pattern=MATCH_NONE):
-        ret = []
-        for proj in self.client.list_projects():
-            if re.search(include_pattern, proj.project_id) and not re.search(exclude_pattern, proj.project_id):
-                ret.append(proj.project_id)
-        return ret
+        return [project.project_id for project in self.client.list_projects() if _filter_by_patterns(project.project_id, include_pattern, exclude_pattern)]
 
     # -------------------------------
     # Dataset
     # -------------------------------
 
     def get_dataset_desc(self, dataset_id) -> DatasetDesc:
-        dataset_ref = self.client.dataset(dataset_id)
-        dataset = self.client.get_dataset(dataset_ref)  # API Request Here
+        dataset = self.client.get_dataset(f'{self.project}.{dataset_id}')  # API Request Here
         dataset_dict = dataset.to_api_repr()
         return DatasetDesc(in_dict=dataset_dict)
 
@@ -63,41 +58,36 @@ class Bigquery:
             existing_dataset_desc: DatasetDesc = self.get_dataset_desc(dataset_id=dataset_id)
             if existing_dataset_desc.description == dataset_desc.description:
                 return BqUpdateResult(True, ResultType.SAME, detail="do nothing")
-            else:
-                ds = bigquery.Dataset(self.client.dataset(dataset_id))
-                ds.description = dataset_desc.description
-                self.client.update_dataset(ds, ['description'])
-                return BqUpdateResult(True, ResultType.UPDATE, f"{existing_dataset_desc.description} -> {dataset_desc.description}")
+
+            self._update_dataset_desc(dataset_id, dataset_desc.description)
+            return BqUpdateResult(True, ResultType.UPDATE, f"{existing_dataset_desc.description} -> {dataset_desc.description}")
+
         except NotFound:
             if self.config.ignore_dataset_not_found_error_when_restore:
-                is_success = True
-            else:
-                is_success = False
-            return BqUpdateResult(is_success, ResultType.DATASET_NOT_FOUND)
+                return BqUpdateResult(True, ResultType.DATASET_NOT_FOUND)
+            return BqUpdateResult(False, ResultType.DATASET_NOT_FOUND)
+
         except BadRequest as e:
             if e.errors[0]["message"].find("Invalid dataset ID") > -1:
                 if self.config.ignore_dataset_not_found_error_when_restore:
-                    is_success = True
-                else:
-                    is_success = False
-                return BqUpdateResult(is_success, ResultType.DATASET_NOT_FOUND, detail=str(e))
+                    return BqUpdateResult(True, ResultType.DATASET_NOT_FOUND, detail=str(e))
+                return BqUpdateResult(False, ResultType.DATASET_NOT_FOUND, detail=str(e))
             raise e
 
+    def _update_dataset_desc(self, dataset_id, new_description):
+        ds = self.client.get_dataset(dataset_id)
+        ds.description = new_description
+        self.client.update_dataset(ds, ['description'])
+
     def list_dataset_id(self, include_pattern=MATCH_ALL, exclude_pattern=MATCH_NONE):
-        ret = []
-        for dataset in self.client.list_datasets():
-            if re.search(include_pattern, dataset.dataset_id) and not re.search(exclude_pattern, dataset.dataset_id):
-                ret.append(dataset.dataset_id)
-        return ret
+        return [dataset.dataset_id for dataset in self.client.list_datasets() if _filter_by_patterns(dataset.dataset_id, include_pattern, exclude_pattern)]
 
     # -------------------------------
     # Table
     # -------------------------------
 
     def get_table_desc(self, dataset_id, table_id) -> TableDesc:
-        dataset_ref = self.client.dataset(dataset_id)
-        table_ref = dataset_ref.table(table_id)
-        table = self.client.get_table(table_ref)  # API Request Here
+        table = self.client.get_table(f'{self.project}.{dataset_id}.{table_id}')  # API Request Here
         table_dict = table.to_api_repr()
         return TableDesc(in_dict=table_dict)
 
@@ -105,43 +95,44 @@ class Bigquery:
         try:
             dataset_id = new_table_desc.dataset_id
             table_id = new_table_desc.table_id
-            now_table_desc = self.get_table_desc(dataset_id=dataset_id, table_id=table_id)
+            existing_table_desc = self.get_table_desc(dataset_id=dataset_id, table_id=table_id)
+
         except NotFound as e:
             if self.config.ignore_table_not_found_error_when_restore:
-                is_success = True
-            else:
-                is_success = False
-            return BqUpdateResult(is_success, ResultType.TABLE_NOT_FOUND, detail=str(e))
+                return BqUpdateResult(True, ResultType.TABLE_NOT_FOUND, detail=str(e))
+            return BqUpdateResult(False, ResultType.TABLE_NOT_FOUND, detail=str(e))
+
         except BadRequest as e:
             if e.errors[0]["message"].find("Invalid table ID") > -1:
-                if self.config.ignore_table_not_found_error_when_restore:
-                    is_success = True
-                else:
-                    is_success = False
+                is_success = self.config.ignore_table_not_found_error_when_restore
                 return BqUpdateResult(is_success, ResultType.TABLE_NOT_FOUND, detail=str(e))
             raise e
-        is_same, diff_msg = new_table_desc.check_diff(now_table_desc)
+
+        is_same, diff_msg = new_table_desc.check_diff(existing_table_desc)
         if is_same:
             return BqUpdateResult(True, ResultType.SAME, detail="do nothing")
-        elif len(now_table_desc.field_list) >= 2 and len(new_table_desc.field_list) >= 2 and \
-                now_table_desc.num_of_field_desc() - new_table_desc.num_of_field_desc() >= 2:
+
+        if len(existing_table_desc.field_list) >= 2 and len(new_table_desc.field_list) >= 2 and \
+           existing_table_desc.num_of_field_desc() - new_table_desc.num_of_field_desc() >= 2:
             msg = "filld description: " + \
-                  f"existing={now_table_desc.num_of_field_desc()}/{len(now_table_desc.field_list)} " + \
+                  f"existing={existing_table_desc.num_of_field_desc()}/{len(existing_table_desc.field_list)} " + \
                   f"new={new_table_desc.num_of_field_desc()}/{len(new_table_desc.field_list)}."
             return BqUpdateResult(False, ResultType.TOO_MANY_DELETION, msg)
-        else:
-            now_table_desc.update_description(other=new_table_desc)
-            generated_dict = now_table_desc.to_dict()
-            generated_dict["tableReference"] = {"projectId": self.project, "datasetId": dataset_id, "tableId": table_id}
-            new_table = bigquery.table.Table.from_api_repr(generated_dict)
-            self.client.update_table(new_table, ["description", "schema"])
-            return BqUpdateResult(True, ResultType.UPDATE, diff_msg)
+
+        self._update_table_desc(dataset_id, table_id, existing_table_desc, new_table_desc)
+        return BqUpdateResult(True, ResultType.UPDATE, diff_msg)
+
+    def _update_table_desc(self, dataset_id, table_id, existing_table_desc, new_table_desc):
+        existing_table_desc.update_description(other=new_table_desc)
+        generated_dict = existing_table_desc.to_dict()
+        generated_dict["tableReference"] = {"projectId": self.project, "datasetId": dataset_id, "tableId": table_id}
+        new_table = bigquery.table.Table.from_api_repr(generated_dict)
+        self.client.update_table(new_table, ["description", "schema"])
 
     def list_table_id(self, dataset_id, include_pattern=MATCH_ALL, exclude_pattern=MATCH_NONE):
-        dataset_ref = self.client.dataset(dataset_id)
-        tables = list(self.client.list_tables(dataset_ref))
-        ret = []
-        for table in tables:
-            if re.search(include_pattern, table.table_id) and not re.search(exclude_pattern, table.table_id):
-                ret.append(table.table_id)
-        return ret
+        tables = list(self.client.list_tables(f'{self.project}.{dataset_id}'))
+        return [table.table_id for table in tables if _filter_by_patterns(table.table_id, include_pattern, exclude_pattern)]
+
+
+def _filter_by_patterns(target, include_pattern, exclude_pattern) -> bool:
+    return re.search(include_pattern, target) and not re.search(exclude_pattern, target)

--- a/src/lib/bigquery.py
+++ b/src/lib/bigquery.py
@@ -131,8 +131,10 @@ class Bigquery:
         self.client.update_table(new_table, ["description", "schema"])
 
     def list_table_id(self, dataset_id, include_pattern=MATCH_ALL, exclude_pattern=MATCH_NONE):
-        tables = list(self.client.list_tables(f'{self.project}.{dataset_id}'))
-        return [table.table_id for table in tables if _filter_by_patterns(table.table_id, include_pattern, exclude_pattern)]
+        return [
+            table.table_id for table in self.client.list_tables(f'{self.project}.{dataset_id}')
+            if _filter_by_patterns(table.table_id, include_pattern, exclude_pattern)
+        ]
 
 
 def _filter_by_patterns(target, include_pattern, exclude_pattern) -> bool:

--- a/test/test_bigquery.py
+++ b/test/test_bigquery.py
@@ -355,21 +355,21 @@ class TestBigqueryLocal(unittest.TestCase):
     def test_update_table_not_exist_dataset_with_ignore_table_not_found_error_when_restore(self):
         org_value = config.ignore_table_not_found_error_when_restore
         try:
-            config.ignore_table_not_found_error_when_restore = True
-            tmp_bq = Bigquery(config, logger)
+            with mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("table not found")), mock.patch('google.cloud.bigquery.Client'):
+                config.ignore_table_not_found_error_when_restore = True
+                tmp_bq = Bigquery(config, logger)
 
-            new_table_dict = {
-                'schema': {
-                    'fields': []
-                },
-                'tableReference': {
-                    "projectId": GCP_PROJECT_ID,
-                    "datasetId": TEST_DS,
-                    "tableId": "does not exist table"
+                new_table_dict = {
+                    'schema': {
+                        'fields': []
+                    },
+                    'tableReference': {
+                        "projectId": GCP_PROJECT_ID,
+                        "datasetId": TEST_DS,
+                        "tableId": "does not exist table"
+                    }
                 }
-            }
-            table_desc = TableDesc(in_dict=new_table_dict)
-            with mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("table not found")):
+                table_desc = TableDesc(in_dict=new_table_dict)
                 bq_update_result = tmp_bq.update_table_desc(table_desc)
                 self.assertEqual(ResultType.TABLE_NOT_FOUND, bq_update_result.type)
                 self.assertEqual(True, bq_update_result.is_success)

--- a/test/test_bigquery.py
+++ b/test/test_bigquery.py
@@ -38,7 +38,7 @@ def dummy_projects():
 
 @pytest.mark.gcp_project
 class TestBigqueryGCP(unittest.TestCase):
-    def setUp(self, client_mock):
+    def setUp(self):
         self.bq = Bigquery(config, logger)
         self.table_reference = {"projectId": GCP_PROJECT_ID, "datasetId": TEST_DS, "tableId": TEST_TABLE}
         self.dataset_reference = {"projectId": GCP_PROJECT_ID, "datasetId": TEST_DS}

--- a/test/test_bigquery.py
+++ b/test/test_bigquery.py
@@ -36,8 +36,9 @@ def dummy_projects():
     return [dummy_project1, dummy_project2]
 
 
-class TestBigquery(unittest.TestCase):
-    def setUp(self):
+@pytest.mark.gcp_project
+class TestBigqueryGCP(unittest.TestCase):
+    def setUp(self, client_mock):
         self.bq = Bigquery(config, logger)
         self.table_reference = {"projectId": GCP_PROJECT_ID, "datasetId": TEST_DS, "tableId": TEST_TABLE}
         self.dataset_reference = {"projectId": GCP_PROJECT_ID, "datasetId": TEST_DS}
@@ -45,7 +46,6 @@ class TestBigquery(unittest.TestCase):
     # -----------------------
     # Table
     # -----------------------
-    @pytest.mark.gcp_project
     def test_get_table__both_table_and_filed_have_desc(self):
         table_name = "both_table_and_filed_have_desc"
         table_desc: TableDesc = self.bq.get_table_desc(TEST_DS, table_name)
@@ -57,35 +57,30 @@ class TestBigquery(unittest.TestCase):
         self.assertEqual(TEST_DS, table_desc.dataset_id)
         self.assertEqual(GCP_PROJECT_ID, table_desc.project_id)
 
-    @pytest.mark.gcp_project
     def test_get_table__col_only_have_desc(self):
         table_desc: TableDesc = self.bq.get_table_desc(TEST_DS, "col_only_have_desc")
         self.assertEqual("", table_desc.description)
         self.assertEqual(1, len(table_desc.field_list))
         self.assertEqual("this is col1 desc", table_desc.field_list[0].description)
 
-    @pytest.mark.gcp_project
     def test_get_table__table_only_have_desc(self):
         table_desc: TableDesc = self.bq.get_table_desc(TEST_DS, "table_only_have_desc")
         self.assertEqual("this is table desc", table_desc.description)
         self.assertEqual(1, len(table_desc.field_list))
         self.assertEqual("", table_desc.field_list[0].description)
 
-    @pytest.mark.gcp_project
     def test_get_table__neither_table_nor_filed_have_desc(self):
         table_desc: TableDesc = self.bq.get_table_desc(TEST_DS, "neither_table_nor_filed_have_desc")
         self.assertEqual("", table_desc.description)
         self.assertEqual(1, len(table_desc.field_list))
         self.assertEqual("", table_desc.field_list[0].description)
 
-    @pytest.mark.gcp_project
     def test_get_table__part_of_cols_have_desc(self):
         table_desc: TableDesc = self.bq.get_table_desc(TEST_DS, "part_of_cols_have_desc")
         self.assertEqual(2, len(table_desc.field_list))
         self.assertEqual("this is col1 desc", table_desc.field_list[0].description)
         self.assertEqual("", table_desc.field_list[1].description)
 
-    @pytest.mark.gcp_project
     def test_update_table_desc(self):
         """
              in     BQ     BQ
@@ -117,7 +112,6 @@ class TestBigquery(unittest.TestCase):
         self.assertEqual('new col1 description' + rand, ret_table_desc.field_list[0].description)
         self.assertEqual('new col2 description' + rand, ret_table_desc.field_list[1].description)
 
-    @pytest.mark.gcp_project
     def test_update_table_desc__one_description_is_empty_string(self):
         """
              in     BQ     BQ
@@ -149,7 +143,6 @@ class TestBigquery(unittest.TestCase):
         self.assertEqual('new col1 description' + rand, ret_table_desc.field_list[0].description)
         self.assertEqual('', ret_table_desc.field_list[1].description)
 
-    @pytest.mark.gcp_project
     def test_update_table_desc__filed_was_added(self):
         """
              in     BQ     BQ
@@ -180,7 +173,6 @@ class TestBigquery(unittest.TestCase):
         self.assertNotEqual('new col2 description' + rand, ret_table_desc.field_list[1].description)
 
     # field was removed
-    @pytest.mark.gcp_project
     def test_update_table_desc__field_was_removed(self):
         """
              in     BQ     BQ
@@ -222,7 +214,6 @@ class TestBigquery(unittest.TestCase):
         self.assertEqual('new col1 description' + rand, ret_table_desc.field_list[0].description)
         self.assertEqual('new col2 description' + rand, ret_table_desc.field_list[1].description)
 
-    @pytest.mark.gcp_project
     def test_update_table_desc__same(self):
         """
              in     BQ     BQ
@@ -234,7 +225,6 @@ class TestBigquery(unittest.TestCase):
         bq_update_result = self.bq.update_table_desc(ret1)
         self.assertEqual(ResultType.SAME, bq_update_result.type)
 
-    @pytest.mark.gcp_project
     def test_update_table_desc__too_many_deletion_error(self):
         """
              in     BQ     BQ
@@ -265,7 +255,6 @@ class TestBigquery(unittest.TestCase):
         bq_update_result = self.bq.update_table_desc(table_desc)
         self.assertEqual(ResultType.TOO_MANY_DELETION, bq_update_result.type)
 
-    @pytest.mark.gcp_project
     def test_update_table_desc__too_many_deletion_error_2(self):
         """
              in     BQ     BQ
@@ -293,7 +282,6 @@ class TestBigquery(unittest.TestCase):
         bq_update_result = self.bq.update_table_desc(table_desc)
         self.assertEqual(ResultType.TOO_MANY_DELETION, bq_update_result.type)
 
-    @pytest.mark.gcp_project
     def test_update_table_desc__with_no_field_list(self):
         """
              in     BQ     BQ
@@ -305,9 +293,42 @@ class TestBigquery(unittest.TestCase):
         table_desc = TableDesc(in_dict=new_table_dict)
         self.bq.update_table_desc(table_desc)
 
+    # ----------------------------
+    # Dataset
+    # ----------------------------
+
+    def test_get_dataset_desc(self):
+        dataset_desc: DatasetDesc = self.bq.get_dataset_desc(TEST_DS)
+        self.assertEqual(TEST_DS, dataset_desc.dataset_id)
+
+    def test_update_dataset_desc(self):
+        ymd_str = "{0}".format(datetime.datetime.now())
+        dataset_desc = DatasetDesc(in_dict={"description": ymd_str, "datasetReference": self.dataset_reference})
+        update_result = self.bq.update_dataset_desc(dataset_desc)
+        self.assertTrue(ResultType.UPDATE, update_result.type)
+        self.assertEqual(ymd_str, self.bq.get_dataset_desc(TEST_DS).description)
+
+    def test_update_dataset_desc_twice(self):
+        ymd_str = "{0}".format(datetime.datetime.now())
+        dataset_desc = DatasetDesc(in_dict={"description": ymd_str, "datasetReference": self.dataset_reference})
+        # update twice
+        _ = self.bq.update_dataset_desc(dataset_desc)
+        update_result = self.bq.update_dataset_desc(dataset_desc)
+        self.assertEqual(ResultType.SAME, update_result.type)
+
+
+class TestBigqueryLocal(unittest.TestCase):
+    def setUp(self):
+        with mock.patch('google.cloud.bigquery.Client'):  # to avoid access GCP project
+            self.bq = Bigquery(config, logger)
+            self.table_reference = {"projectId": GCP_PROJECT_ID, "datasetId": TEST_DS, "tableId": TEST_TABLE}
+            self.dataset_reference = {"projectId": GCP_PROJECT_ID, "datasetId": TEST_DS}
+
+    # -----------------------
+    # Table
+    # -----------------------
     # 存在しない
-    @mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("dataset not found"))
-    def test_update_table_not_exist_dataset(self, get_table_desc_mock):
+    def test_update_table_not_exist_dataset(self):
         new_table_dict = {
             'schema': {
                 'fields': []
@@ -319,19 +340,19 @@ class TestBigquery(unittest.TestCase):
             }
         }
         table_desc = TableDesc(in_dict=new_table_dict)
-        bq_update_result = self.bq.update_table_desc(table_desc)
-        self.assertEqual(ResultType.TABLE_NOT_FOUND, bq_update_result.type)
+        with mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("dataset not found")):
+            bq_update_result = self.bq.update_table_desc(table_desc)
+            self.assertEqual(ResultType.TABLE_NOT_FOUND, bq_update_result.type)
 
-    @mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("table not found"))
-    def test_update_table_not_exist_table(self, get_table_desc_mock):
+    def test_update_table_not_exist_table(self):
         new_table_dict = {'schema': {'fields': []}, 'tableReference': {"projectId": GCP_PROJECT_ID, "datasetId": TEST_DS, "tableId": "does not exist table"}}
         table_desc = TableDesc(in_dict=new_table_dict)
-        bq_update_result = self.bq.update_table_desc(table_desc)
-        self.assertEqual(ResultType.TABLE_NOT_FOUND, bq_update_result.type)
-        self.assertEqual(False, bq_update_result.is_success)
+        with mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("table not found")):
+            bq_update_result = self.bq.update_table_desc(table_desc)
+            self.assertEqual(ResultType.TABLE_NOT_FOUND, bq_update_result.type)
+            self.assertEqual(False, bq_update_result.is_success)
 
-    @mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("table not found"))
-    def test_update_table_not_exist_dataset_with_ignore_table_not_found_error_when_restore(self, get_table_desc_mock):
+    def test_update_table_not_exist_dataset_with_ignore_table_not_found_error_when_restore(self):
         org_value = config.ignore_table_not_found_error_when_restore
         try:
             config.ignore_table_not_found_error_when_restore = True
@@ -348,81 +369,64 @@ class TestBigquery(unittest.TestCase):
                 }
             }
             table_desc = TableDesc(in_dict=new_table_dict)
-            bq_update_result = tmp_bq.update_table_desc(table_desc)
-            self.assertEqual(ResultType.TABLE_NOT_FOUND, bq_update_result.type)
-            self.assertEqual(True, bq_update_result.is_success)
+            with mock.patch('src.lib.bigquery.Bigquery.get_table_desc', side_effect=NotFound("table not found")):
+                bq_update_result = tmp_bq.update_table_desc(table_desc)
+                self.assertEqual(ResultType.TABLE_NOT_FOUND, bq_update_result.type)
+                self.assertEqual(True, bq_update_result.is_success)
         finally:
             config.ignore_table_not_found_error_when_restore = org_value
 
-    @mock.patch('google.cloud.bigquery.Client.list_tables', return_value=dummy_tables())
-    def test_list_table_id(self, list_tables_mock):
-        ret = self.bq.list_table_id(TEST_DS)
-        self.assertEqual('dummy_table1', ret[0])
-        self.assertEqual('dummy_table2', ret[1])
+    def test_list_table_id(self):
+        with mock.patch.object(self.bq, 'client') as client_mock:
+            client_mock.list_tables.return_value = dummy_tables()
+            ret = self.bq.list_table_id(TEST_DS)
+            self.assertEqual('dummy_table1', ret[0])
+            self.assertEqual('dummy_table2', ret[1])
 
     # ----------------------------
     # Dataset
     # ----------------------------
 
-    @mock.patch('google.cloud.bigquery.Client.list_datasets', return_value=dummy_datasets())
-    def test_list_dataset(self, list_datasets_mock):
-        ret = self.bq.list_dataset_id()
-        self.assertEqual('dummy_dataset1', ret[0])
-        self.assertEqual('dummy_dataset2', ret[1])
+    def test_list_dataset(self):
+        with mock.patch.object(self.bq, 'client') as client_mock:
+            client_mock.list_datasets.return_value = dummy_datasets()
 
-    @pytest.mark.gcp_project
-    def test_get_dataset_desc(self):
-        dataset_desc: DatasetDesc = self.bq.get_dataset_desc(TEST_DS)
-        self.assertEqual(TEST_DS, dataset_desc.dataset_id)
+            ret = self.bq.list_dataset_id()
+            self.assertEqual('dummy_dataset1', ret[0])
+            self.assertEqual('dummy_dataset2', ret[1])
 
-    @pytest.mark.gcp_project
-    def test_update_dataset_desc(self):
-        ymd_str = "{0}".format(datetime.datetime.now())
-        dataset_desc = DatasetDesc(in_dict={"description": ymd_str, "datasetReference": self.dataset_reference})
-        update_result = self.bq.update_dataset_desc(dataset_desc)
-        self.assertTrue(ResultType.UPDATE, update_result.type)
-        self.assertEqual(ymd_str, self.bq.get_dataset_desc(TEST_DS).description)
-
-    @pytest.mark.gcp_project
-    def test_update_dataset_desc_twice(self):
-        ymd_str = "{0}".format(datetime.datetime.now())
-        dataset_desc = DatasetDesc(in_dict={"description": ymd_str, "datasetReference": self.dataset_reference})
-        # update twice
-        _ = self.bq.update_dataset_desc(dataset_desc)
-        update_result = self.bq.update_dataset_desc(dataset_desc)
-        self.assertEqual(ResultType.SAME, update_result.type)
-
-    @mock.patch('src.lib.bigquery.Bigquery.get_dataset_desc', side_effect=NotFound("dataset not found"))
-    def test_update_dataset_not_exist_dataset(self, get_dataset_desc_mock):
+    def test_update_dataset_not_exist_dataset(self):
         ymd_str = "{0}".format(datetime.datetime.now())
         dataset_reference = {"projectId": GCP_PROJECT_ID, "datasetId": "does not exist dataset"}
         dataset_desc = DatasetDesc(in_dict={"description": ymd_str, "datasetReference": dataset_reference})
-        bq_update_result = self.bq.update_dataset_desc(dataset_desc)
-        self.assertEqual(ResultType.DATASET_NOT_FOUND, bq_update_result.type)
-        self.assertEqual(False, bq_update_result.is_success)
+        with mock.patch('src.lib.bigquery.Bigquery.get_dataset_desc', side_effect=NotFound("dataset not found")):
+            bq_update_result = self.bq.update_dataset_desc(dataset_desc)
+            self.assertEqual(ResultType.DATASET_NOT_FOUND, bq_update_result.type)
+            self.assertEqual(False, bq_update_result.is_success)
 
-    @mock.patch('src.lib.bigquery.Bigquery.get_dataset_desc', side_effect=NotFound("dataset not found"))
-    def test_update_dataset_not_exist_dataset_with_ignore_dataset_not_found_error_when_restore(self, get_dataset_desc_mock):
+    def test_update_dataset_not_exist_dataset_with_ignore_dataset_not_found_error_when_restore(self):
         org_value = config.ignore_dataset_not_found_error_when_restore
         try:
             config.ignore_dataset_not_found_error_when_restore = True
             ymd_str = "{0}".format(datetime.datetime.now())
             dataset_reference = {"projectId": GCP_PROJECT_ID, "datasetId": "does not exist dataset"}
             dataset_desc = DatasetDesc(in_dict={"description": ymd_str, "datasetReference": dataset_reference})
-            bq_update_result = self.bq.update_dataset_desc(dataset_desc)
-            self.assertEqual(ResultType.DATASET_NOT_FOUND, bq_update_result.type)
-            self.assertEqual(True, bq_update_result.is_success)
+            with mock.patch('src.lib.bigquery.Bigquery.get_dataset_desc', side_effect=NotFound("dataset not found")):
+                bq_update_result = self.bq.update_dataset_desc(dataset_desc)
+                self.assertEqual(ResultType.DATASET_NOT_FOUND, bq_update_result.type)
+                self.assertEqual(True, bq_update_result.is_success)
         finally:
             config.ignore_dataset_not_found_error_when_restore = org_value
 
     # ----------------------------
     # Project
     # ----------------------------
-    @mock.patch('google.cloud.bigquery.Client.list_projects', return_value=dummy_projects())
-    def test_list_project(self, list_projects_mock):
-        ret = self.bq.list_project_id()
-        self.assertEqual('dummy_project1', ret[0])
-        self.assertEqual('dummy_project2', ret[1])
+    def test_list_project(self):
+        with mock.patch.object(self.bq, 'client') as client_mock:
+            client_mock.list_projects.return_value = dummy_projects()
+            ret = self.bq.list_project_id()
+            self.assertEqual('dummy_project1', ret[0])
+            self.assertEqual('dummy_project2', ret[1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What is this PR

I refactored and applied mocks on unit test for bigquery.py.
What I did are:
1. removed deprecated methods (e.g. `google.cloud.bigquery.Client.dataset` )
2. moved some procedures into private functions for testability
3. applied mock on UT and divide GCP integration test and Local unit test